### PR TITLE
Fix GitHub Actions workflow YAML boolean syntax

### DIFF
--- a/.github/workflows/integration-test-matrix.yml
+++ b/.github/workflows/integration-test-matrix.yml
@@ -7,7 +7,7 @@ on:
       force-full-matrix:
         description: 'Run full integration test matrix'
         required: false
-        default: 'false'
+        default: false
         type: boolean
 
 permissions:


### PR DESCRIPTION
## Summary
- Fix YAML boolean syntax error in `integration-test-matrix.yml`
- Change `default: 'false'` to `default: false` for workflow_dispatch input
- Resolves VSCode YAML validation error reporting "Unexpected type 'StringToken', expected 'BooleanToken'"

## Technical Details
GitHub Actions workflow_dispatch inputs with `type: boolean` expect unquoted boolean values (`true`/`false`) rather than quoted strings (`'true'`/`'false'`).

## Test Plan
- [x] YAML syntax validation passes
- [x] Workflow can be manually triggered via GitHub UI
- [x] VSCode no longer reports validation errors

🤖 Generated with [Claude Code](https://claude.ai/code)